### PR TITLE
properly comment unnecessary code inside technicians service

### DIFF
--- a/src/app/services/technicians.service.ts
+++ b/src/app/services/technicians.service.ts
@@ -45,7 +45,7 @@ export class TechniciansService {
   //     var errorMessage = error.message;
   //     // ...
   //   });
-  }
+  // }
 
   
 }


### PR DESCRIPTION
Properly comment some codes (open and close curly braces) not in used inside technicians service that cause errors.